### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Access denied : 0 file(s)
 C:\build>
 ```
 
-##Contribute
+## Contribute
 
 If you want to contribute, please pick up something from our [Github issues](https://github.com/develbranch/TinyAntivirus/issues).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
